### PR TITLE
[Timely] Add per-key slide size

### DIFF
--- a/timely-experiments/Cargo.toml
+++ b/timely-experiments/Cargo.toml
@@ -14,3 +14,4 @@ abomonation_derive = "0.5.0"
 pyo3 = { version = "0.14.3", features = ["auto-initialize"]}
 redis = { version = "0.21.2", features = ["streams"]}
 clap = "2.33.3"
+serde_json = "1.0.68"

--- a/timely-experiments/scripts/run_stl_online.sh
+++ b/timely-experiments/scripts/run_stl_online.sh
@@ -11,8 +11,10 @@ redis-server --save "" --appendonly no &
 
 cargo run --release -- \
     --source=redis \
-    --global_window_size=100 \
+    --global_window_size=672 \
     --global_slide_size=48 \
+    --per_key_slide_size=./result/min_loss_plan.json \
+    --threads=1
     --seasonality=168 &
 
 python ../stl/stl_online_client.py \

--- a/timely-experiments/src/lib.rs
+++ b/timely-experiments/src/lib.rs
@@ -1,4 +1,8 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    collections::HashMap,
+    fs::File,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 pub mod operators;
 mod record;
@@ -10,4 +14,9 @@ pub fn ns_since_unix_epoch() -> u128 {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_nanos()
+}
+
+pub fn parse_per_key_slide_size(filename: &str) -> HashMap<usize, usize> {
+    let file = File::open(filename).unwrap();
+    serde_json::from_reader(file).unwrap()
 }

--- a/timely-experiments/src/operators/source.rs
+++ b/timely-experiments/src/operators/source.rs
@@ -1,5 +1,4 @@
 use std::{
-    str::FromStr,
     thread,
     time::{Duration, Instant},
 };

--- a/timely-experiments/src/operators/window.rs
+++ b/timely-experiments/src/operators/window.rs
@@ -12,6 +12,11 @@ use differential_dataflow::{AsCollection, Collection, Hashable};
 
 pub trait Window<S: Scope, K: Data + ExchangeData, V: Data + ExchangeData> {
     fn sliding_window(&self, window_size: usize, slide_size: usize) -> Collection<S, (K, Vec<V>)>;
+    fn variable_sliding_window(
+        &self,
+        window_size: usize,
+        slide_sizes: HashMap<K, usize>,
+    ) -> Collection<S, (K, Vec<V>)>;
 }
 
 impl<S: Scope, K: Data + Hash + Eq + std::fmt::Debug + ExchangeData, V: Data + ExchangeData>
@@ -46,6 +51,43 @@ impl<S: Scope, K: Data + Hash + Eq + std::fmt::Debug + ExchangeData, V: Data + E
 
                 if entry.len() == window_size {
                     let window = windows.remove(&key).unwrap();
+                    windows.insert(key.clone(), window[slide_size..].into());
+                    vec![((key, window), time, 1)]
+                } else {
+                    vec![]
+                }
+            })
+            .as_collection()
+    }
+
+    fn variable_sliding_window(
+        &self,
+        window_size: usize,
+        slide_sizes: HashMap<K, usize>,
+    ) -> Collection<S, (K, Vec<V>)> {
+        // TODO: don't duplicate code and use a helper function?
+        let mut windows: HashMap<K, Vec<V>> = HashMap::new();
+        self.inner
+            .exchange(|((k, _), _, _)| k.hashed()) // Assign each key to a worker.
+            .flat_map(move |((key, value), time, diff)| {
+                if diff <= 0 {
+                    unimplemented!("Retractions are unsupported for windowing.")
+                }
+
+                let entry = windows
+                    .entry(key.clone())
+                    .or_insert(Vec::with_capacity(window_size));
+                for _ in 1..diff {
+                    entry.push(value.clone());
+                }
+                entry.push(value);
+
+                // TODO: handle negative differences.
+                // TODO: can optimize by by only removing if slide_size == window_size.
+
+                if entry.len() == window_size {
+                    let window = windows.remove(&key).unwrap();
+                    let slide_size: usize = *slide_sizes.get(&key).unwrap();
                     windows.insert(key.clone(), window[slide_size..].into());
                     vec![((key, window), time, 1)]
                 } else {


### PR DESCRIPTION
Set the per-key slide size in window operators by loading the window configuration from a JSON file.

See `timely-experiments/scripts/run_stl_online.sh` for example use.